### PR TITLE
show path in readonly mode

### DIFF
--- a/packages/components/src/form/demos/zhCN/clearable.demo.vue
+++ b/packages/components/src/form/demos/zhCN/clearable.demo.vue
@@ -11,9 +11,11 @@ import { computed, defineComponent } from 'vue'
 export default defineComponent({
   setup() {
     const form = createProForm()
+    const readonly = ref(false)
 
     return {
       form,
+      readonly,
       autoCompleteOptions: computed(() => {
         const value = form.values.value['auto-complete']
         return ['@gmail.com', '@163.com', '@qq.com'].map((suffix) => {
@@ -31,7 +33,7 @@ export default defineComponent({
 
 <template>
   <pro-form-clearable-provider>
-    <pro-form :form="form" label-width="auto">
+    <pro-form :form="form" label-width="auto" :readonly>
       <n-grid :cols="2" x-gap="16">
         <n-gi>
           <pro-date title="date" path="date" />
@@ -137,12 +139,40 @@ export default defineComponent({
         </n-gi>
         <n-gi>
           <pro-tree-select
-            title="select"
-            path="select"
+            title="tree-select"
+            path="tree-select"
             :field-props="{
+              showPath: true,
               options: [
-                { label: '北京', value: 0 },
-                { label: '上海', value: 1 },
+                {
+                  label: 'Rubber Soul',
+                  key: 0,
+                  children: [
+                    {
+                      label: 'Drive My Car',
+                      key: 1,
+
+                    },
+                    {
+                      label: 'Wait',
+                      key: 2,
+                    },
+                  ],
+                },
+                {
+                  label: 'Let It Be',
+                  key: 3,
+                  children: [
+                    {
+                      label: 'For You Blue',
+                      key: 4,
+                    },
+                    {
+                      label: 'Get Back',
+                      key: 5,
+                    },
+                  ],
+                },
               ],
             }"
           />
@@ -158,6 +188,14 @@ export default defineComponent({
         </n-gi>
       </n-grid>
       <n-flex>
+        <n-switch v-model:value="readonly" class="mb-8px">
+          <template #checked>
+            编辑
+          </template>
+          <template #unchecked>
+            只读
+          </template>
+        </n-switch>
         <n-button attr-type="reset">
           重置
         </n-button>


### PR DESCRIPTION
Display path label in  in `readonly` mode when `show-path` is true.

Related components: `tree-select` and `cascader` .

fix some typos in `clearabel.demo` 